### PR TITLE
Fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ and then
 
 ## Configuration
 
-There is some basic configuration options available in the `src/main/resources/application.properties`, but it will work out of the box creating a h2 database in the users home directory.
+There are some basic configuration options available in the `src/main/resources/application.properties`, but it will work out of the box creating a h2 database in the users home directory.


### PR DESCRIPTION
A singular "is" was referring to a plural of "options". Changed to "are"